### PR TITLE
Add deweighted moments and filter matching 

### DIFF
--- a/sf_tools/image/shape.py
+++ b/sf_tools/image/shape.py
@@ -289,9 +289,9 @@ class Ellipticity():
         if match:
             xx = (1-self.e[0]/2)*self.x - self.e[1]/2*self.y
             yy = (1+self.e[0]/2)*self.y - self.e[1]/2*self.x
-            self.x = xx
-            self.y = yy
-        self.weights = np.exp(-(self.x ** 2 + self.y ** 2) /
+        else:
+            xx,yy = self.x, self.y
+        self.weights = np.exp(-(xx ** 2 + yy ** 2) /
                               (2 * self.sigma ** 2))
 
     def update_centroid(self):


### PR DESCRIPTION
As in Melchior et al., 2011.

Both matching, deweighted moments and the higher order moment computation required for the latter should be entirely independent from previous methods (though matching can now be used with any and all of them).

The only change that affects them is in get_centroid, where the initialization is now made on centroid (at center of imagette), then a first guess for the weight function is computed, rather than taking a unitary weighting function. Moments are now also calculated at each iteration of centroid estimation, to allow for matching weights.