### PR TITLE
Update cost function parameters.

### DIFF
--- a/sf_tools/signal/optimisation.py
+++ b/sf_tools/signal/optimisation.py
@@ -460,7 +460,7 @@ class Condat(object):
         self.update_param()
 
         # Test cost function for convergence.
-        self.converge = self.cost_func.get_cost(self.x_new)
+        self.converge = self.cost_func.get_cost(self.x_new, self.y_new)
 
     def iterate(self, max_iter=150):
         r"""Iterate


### PR DESCRIPTION
In some cases we need the primal and dual solutions, for instance when computing the dual gap.